### PR TITLE
タグの編集＋周辺のControllerのテスト

### DIFF
--- a/src/app/Http/Controllers/Article/GetEditPageController.php
+++ b/src/app/Http/Controllers/Article/GetEditPageController.php
@@ -6,11 +6,13 @@ namespace App\Http\Controllers\Article;
 
 use App\Http\Controllers\Controller;
 use App\Models\Article;
+use App\Models\Tag;
 
 class GetEditPageController extends Controller
 {
     public function __invoke(Article $article)
     {
-        return view('articles.edit', compact('article'));
+        $tags = Tag::all();
+        return view('articles.edit', compact('article','tags'));
     }
 }

--- a/src/app/Http/Controllers/Article/UpdateArticleController.php
+++ b/src/app/Http/Controllers/Article/UpdateArticleController.php
@@ -6,6 +6,7 @@ namespace App\Http\Controllers\Article;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\UpdateArticleRequest;
 use App\Models\Article;
+use Illuminate\Database\QueryException;
 use Illuminate\Support\Facades\DB;
 
 
@@ -24,7 +25,9 @@ class UpdateArticleController extends Controller
 
             $article->tags()->sync($request->tags);
             DB::commit();
-
+        } catch (QueryException $e) {
+            DB::rollBack();
+            return redirect()->route('home')->with('error', 'Failed to update article: The tags contain invalid IDs.');
         } catch (\Exception $e) {
             DB::rollBack();
             return redirect()->route('home')->with('error', 'Failed to update article: ' . $e->getMessage());

--- a/src/app/Http/Controllers/Article/UpdateArticleController.php
+++ b/src/app/Http/Controllers/Article/UpdateArticleController.php
@@ -22,6 +22,7 @@ class UpdateArticleController extends Controller
                 $article->thumbnail()->update(['path' => str_replace('public/', '', $path)]);
             }
 
+            $article->tags()->sync($request->tags);
             DB::commit();
 
         } catch (\Exception $e) {

--- a/src/config/filesystems.php
+++ b/src/config/filesystems.php
@@ -39,9 +39,16 @@ return [
         'public' => [
             'driver' => 'local',
             'root' => storage_path('app/public'),
-            'url' => env('APP_URL').'/storage',
+            'url' => env('APP_URL') . '/storage',
             'visibility' => 'public',
             'throw' => false,
+        ],
+
+        'testing' => [
+            'driver' => 'local',
+            'root' => storage_path('framework/testing/disks/public'),
+            'url' => env('APP_URL') . '/storage',
+            'visibility' => 'public',
         ],
 
         's3' => [

--- a/src/phpunit.xml
+++ b/src/phpunit.xml
@@ -29,5 +29,6 @@
         <env name="QUEUE_CONNECTION" value="sync"/>
         <env name="SESSION_DRIVER" value="array"/>
         <env name="TELESCOPE_ENABLED" value="false"/>
+        <env name="FILESYSTEM_DRIVER" value="testing"/>
     </php>
 </phpunit>

--- a/src/resources/views/articles/edit.blade.php
+++ b/src/resources/views/articles/edit.blade.php
@@ -37,6 +37,19 @@
                     <span class="text-danger">{{ $errors->first('thumbnail') }}</span>
                 @endif
             </div>
+            <div class="form-group">
+                <label for="tags">Tags:</label>
+                @foreach ($tags as $tag)
+                    <div class="form-check">
+                        <input class="form-check-input" type="checkbox" id="tag{{ $tag->id }}" name="tags[]" value="{{ $tag->id }}"
+                               @if($article->tags->contains($tag->id)) checked @endif>
+                        <label class="form-check-label" for="tag{{ $tag->id }}">{{ $tag->name }}</label>
+                    </div>
+                @endforeach
+                @if ($errors->has('tags'))
+                    <span class="text-danger">{{ $errors->first('tags') }}</span>
+                @endif
+            </div>
             <button type="submit" class="btn btn-primary">Update</button>
         </form>
     </div>

--- a/src/tests/Feature/Article/GetEditPageControllerTest.php
+++ b/src/tests/Feature/Article/GetEditPageControllerTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Feature\Article;
+
+use App\Models\Article;
+use App\Models\Tag;
+use App\Models\Thumbnail;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class GetEditPageControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_編集ページが適切に表示される()
+{
+    // テストデータの作成
+    $article = Article::factory()
+        ->has(Thumbnail::factory())
+        ->has(Tag::factory()->count(3))
+        ->create();
+
+    // リクエストの実行
+    $response = $this->get(route('articles.get_edit_page', ['article' => $article->id]));
+
+    // デバッグ情報の出力
+    $response->dumpHeaders();
+    $response->dumpSession();
+    $response->dump();
+
+    // アサーション
+    $response->assertStatus(200);
+    $response->assertViewIs('articles.edit');
+    $response->assertViewHas('article', $article);
+
+    // input フィールドの value 属性を確認
+    $response->assertSee('value="' . $article->title . '"', false);
+
+    // textarea のテキストを確認
+    $html = $response->getContent();
+    $this->assertMatchesRegularExpression('/<textarea[^>]*>' . preg_quote($article->body, '/') . '<\/textarea>/', $html);
+
+    // タグが表示されていることを確認
+    foreach ($article->tags as $tag) {
+        $response->assertSeeText($tag->name);
+    }
+}
+}

--- a/src/tests/Feature/Article/UpdateArticleControllerTest.php
+++ b/src/tests/Feature/Article/UpdateArticleControllerTest.php
@@ -1,0 +1,98 @@
+<?php
+
+declare (strict_types=1);
+
+namespace Feature\Article;
+
+
+use App\Models\Article;
+use App\Models\Tag;
+use App\Models\Thumbnail;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
+use Tests\TestCase;
+
+class UpdateArticleControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_記事が正常に更新される()
+    {
+        // ストレージをモック
+        Storage::fake('testing');
+
+        // テストデータの作成
+        $article = Article::factory()
+            ->has(Thumbnail::factory())
+            ->has(Tag::factory()->count(3))
+            ->create();
+
+        // 更新データの準備
+        $newTitle = 'Updated Title';
+        $newBody = 'Updated Body';
+        $newTags = Tag::factory()->count(2)->create()->pluck('id')->toArray();
+        $newThumbnail = UploadedFile::fake()->image('new_thumbnail.jpg');
+
+        // リクエストの実行
+        $response = $this->put(route('articles.update_article', $article), [
+            'title' => $newTitle,
+            'body' => $newBody,
+            'tags' => $newTags,
+            'thumbnail' => $newThumbnail,
+        ]);
+
+        // アサーション
+        $response->assertRedirect(route('home'));
+        $response->assertSessionHas('success', 'Article updated successfully.');
+
+        // 更新されたデータを再取得
+        $article->refresh();
+
+        // 記事が更新されていることを確認
+        $this->assertEquals($newTitle, $article->title);
+        $this->assertEquals($newBody, $article->body);
+
+        // サムネイルが更新されていることを確認
+        Storage::disk('public')->assertExists('thumbnails/' . $newThumbnail->hashName());
+        $this->assertEquals('thumbnails/' . $newThumbnail->hashName(), $article->thumbnail->path);
+
+        // タグが更新されていることを確認
+        $this->assertCount(2, $article->tags);
+        $this->assertEquals($newTags, $article->tags->pluck('id')->toArray());
+    }
+
+    public function test_例外発生時にロールバックされる()
+    {
+        // ストレージをモック
+        Storage::fake('testing');
+        // テストデータの作成
+        $article = Article::factory()
+            ->has(Thumbnail::factory())
+            ->has(Tag::factory()->count(3))
+            ->create();
+
+        // 無効なデータを準備して、例外を引き起こす
+        $invalidData = [
+            'title' => 'Updated Title',
+            'body' => 'Updated Body',
+            'tags' => [9999], // 存在しないタグID
+            'thumbnail' => UploadedFile::fake()->image('new_thumbnail.jpg'),
+        ];
+
+        // リクエストの実行
+        $response = $this->put(route('articles.update_article', $article), $invalidData);
+
+        // アサーション
+        $response->assertRedirect(route('home'));
+        $response->assertSessionHas('error', 'Failed to update article: The tags contain invalid IDs.');
+
+        // 記事が更新されていないことを確認
+        $article->refresh();
+        $this->assertNotEquals('Updated Title', $article->title);
+        $this->assertNotEquals('Updated Body', $article->body);
+
+        // サムネイルが更新されていないことを確認
+        Storage::disk('public')->assertMissing('thumbnails/new_thumbnail.jpg');
+    }
+}


### PR DESCRIPTION
記事編集画面でタグを編集できるようにしました。
phpunitの時だけ、test用のファイルシステムを使うようにも変更を加えています。


![image](https://github.com/kojikokojiko/kensyu-laravel/assets/48917379/a2f9c11a-e32f-4fde-8f91-c8d3fd25d044)
